### PR TITLE
WIP integration of eager mode with IREE and GPU

### DIFF
--- a/python/torch_mlir/eager_mode/iree_backend.py
+++ b/python/torch_mlir/eager_mode/iree_backend.py
@@ -1,0 +1,52 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import iree.compiler as ireec
+import iree.runtime as ireert
+from torch_mlir_e2e_test.linalg_on_tensors_backends.abc import LinalgOnTensorsBackend
+
+IREE_DEVICE_MAP = {"cuda:0": "cuda", "cpu": "dylib", "gpu": "cuda", "vulkan": "vulkan"}
+
+class IREEInvoker:
+    def __init__(self, iree_module):
+        self._iree_module = iree_module
+
+    def __getattr__(self, function_name: str):
+        def invoke(*args):
+            return self._iree_module[function_name](*args)
+
+        return invoke
+
+
+class IREELinalgOnTensorsBackend(LinalgOnTensorsBackend):
+    """Main entry-point for the reference backend."""
+
+    def __init__(self, device):
+        super().__init__()
+        self.device = IREE_DEVICE_MAP[device]
+
+    def compile(self, imported_module):
+        """Compiles an imported module, with a flat list of functions.
+        The module is expected to be in linalg-on-tensors + scalar code form.
+        TODO: More clearly define the backend contract. Generally this will
+        extend to support globals, lists, and other stuff.
+
+        Args:
+          imported_module: The MLIR module consisting of funcs in the torch
+            dialect.
+        Returns:
+          An opaque, backend specific compiled artifact object that can be
+          passed to `load`.
+        """
+        return ireec.compile_str(str(imported_module), target_backends=[self.device])
+
+    def load(self, flatbuffer) -> IREEInvoker:
+        """Loads a compiled artifact into the runtime."""
+        vm_module = ireert.VmModule.from_flatbuffer(flatbuffer)
+        config = ireert.Config(driver_name=self.device)
+        ctx = ireert.SystemContext(config=config)
+        ctx.add_vm_module(vm_module)
+        return IREEInvoker(ctx.modules.module)


### PR DESCRIPTION
In order to be able to deploy to GPUs.

test script:

```
mod = Linear()
t = torch.randn((10000, 10000)).to("cuda")
u = torch.randn((10000, 10000)).to("cuda")

tt = TorchMLIRTensor(t)
uu = TorchMLIRTensor(u)
print(tt.device, uu.device)
yy = mod(tt, uu)
print(yy, yy.device)

>>>cuda:0 cuda:0
TorchMLIRTensor(tensor([[-2.1213, -2.3596, -0.5263,  ...,  0.6850,  1.5653, -1.4307],
        [-2.3914,  0.6371,  0.8954,  ...,  2.5500,  0.5786, -0.7404],
        [ 0.5575, -0.4763,  1.8513,  ..., -0.2012,  0.6808, -0.3168],
        ...,
        [-0.8099, -2.9647,  0.6572,  ..., -0.9472, -0.2818, -0.6804],
        [-0.0209,  1.8940, -1.5187,  ...,  1.2398,  0.2595, -0.4353],
        [ 1.0092,  1.1264,  0.4485,  ..., -0.6481, -1.2947, -0.8934]])) cuda:0
```

Currently incurs lots of copy overhead.

This is just a temporary staging branch until things settle (Ie iree changes will be PR'd to iree)